### PR TITLE
fix(typo): thrustworthiness -> trustworthiness

### DIFF
--- a/src/content/docs/basics/why.mdx
+++ b/src/content/docs/basics/why.mdx
@@ -138,7 +138,7 @@ That way, you can use it as a generic OpenID provider for a "Sign in with..." bu
 ### Detect bots and fake accounts
 
 For websites, it is difficult to distinguish real users from fake ones like bots.
-A "reputation" associated to users helps to determine their thrustworthiness.
+A "reputation" associated to users helps to determine their trustworthiness.
 The reputation for example increases with verified informations (e-mail, phone, multi-devices, identity) and behavior (account age, regular activity)
 while it decreases upon complaints. The whole in a privacy-preserving way of course.
 


### PR DESCRIPTION
I noticed this typo in the [old docs](https://github.com/passwordless-id/webauthn/pull/82) and decided to check if the new docs had them as well. Fixing here as well. 